### PR TITLE
feat: Todo登録機能の実装

### DIFF
--- a/src/main/java/com/example/springboot_todo_app/controller/HomeController.java
+++ b/src/main/java/com/example/springboot_todo_app/controller/HomeController.java
@@ -1,6 +1,6 @@
 package com.example.springboot_todo_app.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import com.example.springboot_todo_app.service.TodoService;
@@ -9,7 +9,7 @@ import com.example.springboot_todo_app.dto.TodoListResponse;
 
 /**
  * Todoアプリケーションのホーム画面用コントローラー
- * Todoアイテムの一覧表示などの基本機能を提供します
+ * Todoアイテムの一覧表示機能を提供します
  */
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/example/springboot_todo_app/controller/TodoController.java
+++ b/src/main/java/com/example/springboot_todo_app/controller/TodoController.java
@@ -1,0 +1,33 @@
+package com.example.springboot_todo_app.controller;
+
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import com.example.springboot_todo_app.service.TodoService;
+import lombok.RequiredArgsConstructor;
+import com.example.springboot_todo_app.dto.TodoRegisterRequest;
+import com.example.springboot_todo_app.entity.TodoItem;
+
+/**
+ * Todoアイテムの操作に関するコントローラー
+ * 登録、更新、削除などの操作を提供します
+ */
+@RestController
+@RequiredArgsConstructor
+@CrossOrigin(origins = "http://localhost:3000")
+@RequestMapping("/todos")
+public class TodoController {
+
+  private final TodoService todoService;
+
+  /**
+   * 新しいTodoアイテムを登録するエンドポイント
+   *
+   * @param request 登録するTodoアイテムの情報
+   * @return 登録されたTodoアイテム
+   */
+  @PostMapping("/register")
+  public TodoItem registerTodo(@RequestBody TodoRegisterRequest request) {
+    return todoService.registerTodo(request.getTitle(), request.getDescription());
+  }
+}

--- a/src/main/java/com/example/springboot_todo_app/dto/TodoRegisterRequest.java
+++ b/src/main/java/com/example/springboot_todo_app/dto/TodoRegisterRequest.java
@@ -1,0 +1,20 @@
+package com.example.springboot_todo_app.dto;
+
+import lombok.Data;
+
+/**
+ * Todoアイテム登録用のリクエストDTO
+ * フロントエンドから送信される登録データをマッピングします
+ */
+@Data
+public class TodoRegisterRequest {
+  /**
+   * Todoアイテムのタイトル
+   */
+  private String title;
+
+  /**
+   * Todoアイテムの説明
+   */
+  private String description;
+}

--- a/src/main/java/com/example/springboot_todo_app/entity/TodoItem.java
+++ b/src/main/java/com/example/springboot_todo_app/entity/TodoItem.java
@@ -35,7 +35,7 @@ public class TodoItem {
   /**
    * Todoアイテムの作成日時
    */
-  @Column(name = "created_at", nullable = false)
+  @Column(name = "created_at", nullable = false, updatable = false)
   @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss")
   private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/springboot_todo_app/repository/TodoItemRepository.java
+++ b/src/main/java/com/example/springboot_todo_app/repository/TodoItemRepository.java
@@ -2,8 +2,17 @@ package com.example.springboot_todo_app.repository;
 
 import com.example.springboot_todo_app.entity.TodoItem;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import java.util.List;
 
-@Repository
+/**
+ * Todoアイテムのリポジトリインターフェース
+ * データベースアクセスに関する操作を提供します
+ */
 public interface TodoItemRepository extends JpaRepository<TodoItem, Long> {
+  /**
+   * すべてのTodoアイテムを作成日時の降順で取得します
+   *
+   * @return 作成日時の降順でソートされたTodoアイテムのリスト
+   */
+  List<TodoItem> findAllByOrderByCreatedAtDesc();
 }

--- a/src/main/java/com/example/springboot_todo_app/service/TodoService.java
+++ b/src/main/java/com/example/springboot_todo_app/service/TodoService.java
@@ -9,8 +9,18 @@ import java.util.List;
 public interface TodoService {
   /**
    * すべてのTodoアイテムを取得します
+   * 作成日時の降順（新しい順）でソートされます
    *
-   * @return Todoアイテムのリスト
+   * @return 作成日時の降順でソートされたTodoアイテムのリスト
    */
   List<TodoItem> getAllTodos();
+
+  /**
+   * 新しいTodoアイテムを登録します
+   *
+   * @param title       Todoアイテムのタイトル
+   * @param description Todoアイテムの説明
+   * @return 登録されたTodoアイテム
+   */
+  TodoItem registerTodo(String title, String description);
 }

--- a/src/main/java/com/example/springboot_todo_app/service/TodoServiceImpl.java
+++ b/src/main/java/com/example/springboot_todo_app/service/TodoServiceImpl.java
@@ -18,10 +18,22 @@ public class TodoServiceImpl implements TodoService {
 
   /**
    * {@inheritDoc}
-   * リポジトリからすべてのTodoアイテムを取得します
+   * リポジトリからすべてのTodoアイテムを取得し、作成日時の降順でソートします
    */
   @Override
   public List<TodoItem> getAllTodos() {
-    return todoItemRepository.findAll();
+    return todoItemRepository.findAllByOrderByCreatedAtDesc();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 新しいTodoアイテムを作成し、リポジトリに保存します
+   */
+  @Override
+  public TodoItem registerTodo(String title, String description) {
+    TodoItem todoItem = new TodoItem();
+    todoItem.setTitle(title);
+    todoItem.setDescription(description);
+    return todoItemRepository.save(todoItem);
   }
 }


### PR DESCRIPTION
# feat: Todo登録機能の実装

## 変更内容
- Todoアイテムの登録機能を実装
- コントローラーの責務分離
- データのソート順を新しい順に変更

## 実装詳細
1. 新規ファイル
   - `TodoController.java`: Todo操作に関するコントローラー
   - `TodoRegisterRequest.java`: 登録用のリクエストDTO

2. 修正ファイル
   - `HomeController.java`: 一覧表示機能のみに責務を限定
   - `TodoService.java`: 登録機能のインターフェース追加
   - `TodoServiceImpl.java`: 登録機能の実装とソート順の変更
   - `TodoItemRepository.java`: 降順ソート用のメソッド追加

## テスト方法
1. アプリケーションを起動
2. フロントエンドから以下のJSONでPOSTリクエストを送信
```json
{
  "title": "テストタスク",
  "description": "テスト説明"
}
```
3. 一覧画面で新しいタスクが最上部に表示されることを確認

## 関連Issue
Closes #2