### PR TITLE
feat: Todo編集機能の実装

### DIFF
--- a/src/main/java/com/example/springboot_todo_app/controller/TodoController.java
+++ b/src/main/java/com/example/springboot_todo_app/controller/TodoController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import com.example.springboot_todo_app.service.TodoService;
 import lombok.RequiredArgsConstructor;
 import com.example.springboot_todo_app.dto.TodoRegisterRequest;
+import com.example.springboot_todo_app.dto.TodoUpdateRequest;
 import com.example.springboot_todo_app.entity.TodoItem;
 
 /**
@@ -40,5 +41,17 @@ public class TodoController {
   @GetMapping("/{id}/edit")
   public TodoItem getTodo(@PathVariable String id) {
     return todoService.getTodo(Long.parseLong(id));
+  }
+
+  /**
+   * 指定されたIDのTodoアイテムを更新するエンドポイント
+   *
+   * @param id      更新するTodoアイテムのID（文字列形式）
+   * @param request 更新するTodoアイテムの情報（タイトルと説明）
+   * @return 更新されたTodoアイテム
+   */
+  @PutMapping("/{id}/update")
+  public TodoItem updateTodo(@PathVariable String id, @RequestBody TodoUpdateRequest request) {
+    return todoService.updateTodo(Long.parseLong(id), request.getTitle(), request.getDescription());
   }
 }

--- a/src/main/java/com/example/springboot_todo_app/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/example/springboot_todo_app/dto/TodoUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.example.springboot_todo_app.dto;
+
+import lombok.Data;
+
+/**
+ * Todoアイテム登録用のリクエストDTO
+ * フロントエンドから送信される登録データをマッピングします
+ */
+@Data
+public class TodoUpdateRequest {
+  /**
+   * Todoアイテムのタイトル
+   */
+  private String title;
+
+  /**
+   * Todoアイテムの説明
+   */
+  private String description;
+}

--- a/src/main/java/com/example/springboot_todo_app/service/TodoService.java
+++ b/src/main/java/com/example/springboot_todo_app/service/TodoService.java
@@ -10,7 +10,7 @@ public interface TodoService {
   /**
    * 指定されたIDのTodoアイテムを取得します
    *
-   * @param id TodoアイテムのID
+   * @param id 取得するTodoアイテムのID
    * @return 指定されたIDのTodoアイテム
    */
   TodoItem getTodo(Long id);
@@ -31,4 +31,16 @@ public interface TodoService {
    * @return 登録されたTodoアイテム
    */
   TodoItem registerTodo(String title, String description);
+
+  /**
+   * 指定されたIDのTodoアイテムを更新します
+   * アイテムが存在しない場合は例外をスローします
+   *
+   * @param id          更新するTodoアイテムのID
+   * @param title       新しいタイトル
+   * @param description 新しい説明
+   * @return 更新されたTodoアイテム
+   * @throws RuntimeException 指定されたIDのTodoアイテムが存在しない場合
+   */
+  TodoItem updateTodo(Long id, String title, String description);
 }

--- a/src/main/java/com/example/springboot_todo_app/service/TodoServiceImpl.java
+++ b/src/main/java/com/example/springboot_todo_app/service/TodoServiceImpl.java
@@ -51,4 +51,26 @@ public class TodoServiceImpl implements TodoService {
     todoItem.setDescription(description);
     return todoItemRepository.save(todoItem);
   }
+
+  /**
+   * {@inheritDoc}
+   * 指定されたIDのTodoアイテムを更新します。
+   * アイテムが存在しない場合は例外をスローします。
+   *
+   * @param id          更新するTodoアイテムのID
+   * @param title       新しいタイトル
+   * @param description 新しい説明
+   * @return 更新されたTodoアイテム
+   * @throws RuntimeException 指定されたIDのTodoアイテムが存在しない場合
+   */
+  @Override
+  public TodoItem updateTodo(Long id, String title, String description) {
+    TodoItem targetTodo = todoItemRepository.findById(id)
+        .orElseThrow(() -> new RuntimeException("Todo not found with id: " + id));
+
+    targetTodo.setTitle(title);
+    targetTodo.setDescription(description);
+
+    return todoItemRepository.save(targetTodo);
+  }
 }


### PR DESCRIPTION
# feat: Todo編集機能の実装

## 変更内容
- Todoアイテムの編集機能を実装
- 編集画面用のAPIエンドポイントを追加
- 更新用のDTOクラスを追加
- JavaDocコメントを追加

## 実装詳細
1. バックエンド
   - `TodoService`に`updateTodo`メソッドを追加
   - `TodoController`に`PUT /todos/{id}/update`エンドポイントを追加
   - `TodoUpdateRequest`DTOクラスを作成

2. エンドポイント
   - 編集画面表示: `GET /todos/{id}/edit`
   - 更新処理: `PUT /todos/{id}/update`

## テスト方法
1. 編集画面表示
   - `GET /todos/{id}/edit`にアクセス
   - 指定したIDのTodoアイテムの情報が返却されることを確認

2. 更新処理
   - `PUT /todos/{id}/update`にリクエストを送信
   - リクエストボディに`title`と`description`を含める
   - 更新されたTodoアイテムが返却されることを確認

## 関連Issue
Closes #3