### PR TITLE
feat: Todoアイテムに完了状態（completed）フィールドを追加

### DIFF
--- a/src/main/java/com/example/springboot_todo_app/controller/TodoController.java
+++ b/src/main/java/com/example/springboot_todo_app/controller/TodoController.java
@@ -42,6 +42,7 @@ public class TodoController {
 
   /**
    * 新しいTodoアイテムを登録するエンドポイント
+   * 登録時は常に未完了（false）状態で作成されます
    *
    * @param request 登録するTodoアイテムの情報
    * @return 登録されたTodoアイテム
@@ -69,7 +70,7 @@ public class TodoController {
    * 指定されたIDのTodoアイテムを更新するエンドポイント
    *
    * @param id      更新するTodoアイテムのID（文字列形式）
-   * @param request 更新するTodoアイテムの情報（タイトルと説明）
+   * @param request 更新するTodoアイテムの情報（タイトル、説明、完了状態）
    * @return 更新されたTodoアイテム
    */
   @PutMapping("/todos/{id}/update")
@@ -77,7 +78,8 @@ public class TodoController {
   public TodoItem updateTodo(
       @PathVariable @NotBlank @Pattern(regexp = "^[0-9]+$", message = "ID must be numeric") String id,
       @Validated @RequestBody TodoUpdateRequest request) {
-    return todoService.updateTodo(Long.parseLong(id), request.getTitle(), request.getDescription());
+    return todoService.updateTodo(Long.parseLong(id), request.getTitle(), request.getDescription(),
+        request.isCompleted());
   }
 
   /**

--- a/src/main/java/com/example/springboot_todo_app/dto/TodoRegisterRequest.java
+++ b/src/main/java/com/example/springboot_todo_app/dto/TodoRegisterRequest.java
@@ -1,6 +1,7 @@
 package com.example.springboot_todo_app.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
 
 /**
  * Todoアイテム登録用のリクエストDTO
@@ -11,10 +12,19 @@ public class TodoRegisterRequest {
   /**
    * Todoアイテムのタイトル
    */
+  @NotBlank(message = "タイトルは必須です")
   private String title;
 
   /**
    * Todoアイテムの説明
    */
+  @NotBlank(message = "説明は必須です")
   private String description;
+
+  /**
+   * Todoアイテムの完了状態
+   * true: 完了
+   * false: 未完了
+   */
+  private boolean completed = false;
 }

--- a/src/main/java/com/example/springboot_todo_app/dto/TodoUpdateRequest.java
+++ b/src/main/java/com/example/springboot_todo_app/dto/TodoUpdateRequest.java
@@ -1,20 +1,29 @@
 package com.example.springboot_todo_app.dto;
 
 import lombok.Data;
+import jakarta.validation.constraints.NotBlank;
 
 /**
- * Todoアイテム登録用のリクエストDTO
- * フロントエンドから送信される登録データをマッピングします
+ * Todoアイテム更新時のリクエストDTO
  */
 @Data
 public class TodoUpdateRequest {
   /**
    * Todoアイテムのタイトル
    */
+  @NotBlank(message = "タイトルは必須です")
   private String title;
 
   /**
    * Todoアイテムの説明
    */
+  @NotBlank(message = "説明は必須です")
   private String description;
+
+  /**
+   * Todoアイテムの完了状態
+   * true: 完了
+   * false: 未完了
+   */
+  private boolean completed;
 }

--- a/src/main/java/com/example/springboot_todo_app/entity/TodoItem.java
+++ b/src/main/java/com/example/springboot_todo_app/entity/TodoItem.java
@@ -33,6 +33,14 @@ public class TodoItem {
   private String description;
 
   /**
+   * Todoアイテムの完了状態
+   * true: 完了（1）
+   * false: 未完了（0）
+   */
+  @Column(nullable = false, columnDefinition = "TINYINT(1)")
+  private boolean completed = false;
+
+  /**
    * Todoアイテムの作成日時
    */
   @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/example/springboot_todo_app/service/TodoService.java
+++ b/src/main/java/com/example/springboot_todo_app/service/TodoService.java
@@ -25,6 +25,7 @@ public interface TodoService {
 
   /**
    * 新しいTodoアイテムを登録します
+   * 登録時は常に未完了（false）状態で作成されます
    *
    * @param title       Todoアイテムのタイトル
    * @param description Todoアイテムの説明
@@ -39,10 +40,11 @@ public interface TodoService {
    * @param id          更新するTodoアイテムのID
    * @param title       新しいタイトル
    * @param description 新しい説明
+   * @param completed   新しい完了状態
    * @return 更新されたTodoアイテム
    * @throws RuntimeException 指定されたIDのTodoアイテムが存在しない場合
    */
-  TodoItem updateTodo(Long id, String title, String description);
+  TodoItem updateTodo(Long id, String title, String description, boolean completed);
 
   /**
    * 指定されたIDのTodoアイテムを削除します

--- a/src/main/java/com/example/springboot_todo_app/service/TodoServiceImpl.java
+++ b/src/main/java/com/example/springboot_todo_app/service/TodoServiceImpl.java
@@ -44,12 +44,14 @@ public class TodoServiceImpl implements TodoService {
   /**
    * {@inheritDoc}
    * 新しいTodoアイテムを作成し、リポジトリに保存します
+   * 登録時は常に未完了（false）状態で作成されます
    */
   @Override
   public TodoItem registerTodo(String title, String description) {
     TodoItem todoItem = new TodoItem();
     todoItem.setTitle(title);
     todoItem.setDescription(description);
+    todoItem.setCompleted(false); // 常に未完了状態で作成
     return todoItemRepository.save(todoItem);
   }
 
@@ -61,16 +63,18 @@ public class TodoServiceImpl implements TodoService {
    * @param id          更新するTodoアイテムのID
    * @param title       新しいタイトル
    * @param description 新しい説明
+   * @param completed   新しい完了状態
    * @return 更新されたTodoアイテム
    * @throws TodoNotFoundException 指定されたIDのTodoアイテムが存在しない場合
    */
   @Override
-  public TodoItem updateTodo(Long id, String title, String description) {
+  public TodoItem updateTodo(Long id, String title, String description, boolean completed) {
     TodoItem targetTodo = todoItemRepository.findById(id)
         .orElseThrow(() -> new TodoNotFoundException("Todo not found with id: " + id));
 
     targetTodo.setTitle(title);
     targetTodo.setDescription(description);
+    targetTodo.setCompleted(completed);
 
     return todoItemRepository.save(targetTodo);
   }


### PR DESCRIPTION
# feat: Todoアイテムに完了状態（completed）フィールドを追加

## 変更内容
- Todoアイテムに完了状態（completed）フィールドを追加
- 新規登録時は常に未完了（false）状態で作成されるように実装
- 更新時は完了状態を変更可能に実装

## 実装詳細
1. エンティティの修正
   - `TodoItem`エンティティに`completed`フィールドを追加
   - MySQLの`TINYINT(1)`型とマッピング
   - デフォルト値を`false`に設定

2. DTOの修正
   - `TodoRegisterRequest`と`TodoUpdateRequest`に`completed`フィールドを追加
   - バリデーションアノテーションの追加

3. サービスの修正
   - `TodoService`インターフェースのメソッドを更新
   - `TodoServiceImpl`で新規登録時は常に`false`を設定
   - 更新時は完了状態の変更を実装

4. コントローラーの修正
   - 登録・更新エンドポイントで完了状態を扱えるように修正
   - 適切なJavaDocコメントの追加

## テスト方法
1. 新規登録のテスト
   - 新しいTodoアイテムを登録
   - 完了状態が`false`で作成されることを確認

2. 更新のテスト
   - 既存のTodoアイテムを更新
   - 完了状態を`true`に変更
   - 変更が正しく反映されることを確認

## 関連Issue
Closes #4